### PR TITLE
Add Interpreter parameter to Manager and Repeater class

### DIFF
--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -29,12 +29,21 @@ class Repeater:
     """
 
     def __init__(
-        self, executable="./execute.sh", inputfile="temp.json", outputfile="temp.nc"
+        self, executable="./execute.sh", inputfile="temp.json", outputfile="temp.nc",
+        interpreter: str | list[str] = None
     ):
         """Set the executable and files to use in the run method"""
         self.executable = executable
         self.inputfile = inputfile
         self.outputfile = outputfile
+        if interpreter is None or len(interpreter) == 0:
+            self.interpreter = []
+        elif type(interpreter) == str:
+            self.interpreter = interpreter.split()
+        elif type(interpreter) == list:
+            self.interpreter = interpreter
+        else:
+            raise Exception("interpreter must be None, a string or a list of strings")
 
     @property
     def executable(self):
@@ -47,6 +56,10 @@ class Repeater:
     @property
     def outputfile(self):
         return self.__outputfile
+    
+    @property
+    def interpreter(self):
+        return self.__interpreter
 
     @executable.setter
     def executable(self, executable):
@@ -59,6 +72,17 @@ class Repeater:
     @outputfile.setter
     def outputfile(self, outputfile):
         self.__outputfile = outputfile
+
+    @interpreter.setter
+    def interpreter(self, interpreter):
+        if interpreter is None or len(interpreter) == 0:
+            self.__interpreter = []
+        elif type(interpreter) == str:
+            self.__interpreter = interpreter.split()
+        elif type(interpreter) == list:
+            self.__interpreter = interpreter
+        else:
+            raise Exception("interpreter must be None, a string or a list of strings")
 
     def run(self, js: JSONDict, error: str = "display", stdout: str = "ignore"):
         """Write inputfile and then run a simulation
@@ -82,7 +106,7 @@ class Repeater:
             json.dump(js, f, sort_keys=True, ensure_ascii=True, indent=4)
         try:
             process = subprocess.run(
-                [self.__executable, self.__inputfile, self.__outputfile],
+                self.__interpreter + [self.__executable, self.__inputfile, self.__outputfile],
                 check=True,
                 capture_output=True,
             )
@@ -147,6 +171,7 @@ class Manager:
         directory: PathLike = "./data",
         filetype: str = "nc",
         executable: str = "./execute.sh",
+        interpreter: str | list[str] | None = None,
     ):
         """Init the Manager class
 
@@ -159,6 +184,7 @@ class Manager:
 
             subprocess.run(
                 [
+                    interpreter,
                     executable,
                     directory/hashid.json,
                     directory/hashid0xN.filetype,
@@ -178,18 +204,36 @@ class Manager:
             file extension of the output files
         executable:
             The executable that generates the data.
-            executable is called using subprocess.run([executable,
-            directory/hashid.json, directory/hashid.filetype],...) with 2 arguments
-            - a json file as input (do not change the input else the file is not
+            executable is called using subprocess.run([interpreter, executable, 
+            directory/hashid.json, directory/hashid.filetype],...) with
+            2 arguments - a json file as input (do not change the input else the file is not
             recognized any more) and one output file (that executable needs to
             generate) (if your code does not take json as input you can for example
             parse json in bash using jq)
-
+        interpreter:
+            (optional) If your executable is not directly runnable but needs to be
+            called via an interpreter (e.g. python, julia, R, powershell, etc.) you can
+            specify the interpreter here as a whitespace separated string or list of strings.
+            For example if your executable is a python script you can set interpreter="python.exe"
+            and the code will be called as subprocess.run(["python.exe", executable, ...],...)
+            You can also include interpreter arguments here. For example to run in a specific 
+            conda environment, set interpreter=["conda", "run", "-n", "myenv"]
+            or interpreter="conda run -n myenv" and the code will be called as
+            subprocess.run(["conda", "run", "-n", "myenv", executable, ...],...)
         """
         self.directory = directory
         os.makedirs(self.__directory, exist_ok=True)
         self.filetype = filetype
         self.executable = executable
+                
+        if interpreter is None or len(interpreter) == 0:
+            self.interpreter = []
+        elif type(interpreter) == str:
+            self.interpreter = interpreter.split()
+        elif type(interpreter) == list:
+            self.interpreter = interpreter
+        else:
+            raise Exception("interpreter must be None, a string or a list of strings")
 
     @property
     def directory(self) -> PathLike:
@@ -203,7 +247,7 @@ class Manager:
     def executable(self) -> str:
         """The executable that generates the data.
 
-        The create method calls subprocess.run([executable,
+        The create method calls subprocess.run([interpreter, executable,
         directory/hashid.json, directory/hashid.filetype],...) that is it must
         take 2 arguments - a json file as input (do not change the input else
         the file is not recognized any more) and one output file (that
@@ -214,7 +258,7 @@ class Manager:
         ----------------------------------
         If you intend to use the restart option (by passing a simulation number
         n>0 to create), the executable is called with
-        subprocess.run([executable, directory/hashid.json,
+        subprocess.run([interpreter, executable, directory/hashid.json,
         directory/hashid0xN.filetype, directory/hashid0x(N-1).filetype],...)
         that is it must take a third argument (the previous simulation)
         """
@@ -224,6 +268,11 @@ class Manager:
     def filetype(self) -> str:
         """File extension of the output files"""
         return self.__filetype
+    
+    @property
+    def interpreter(self) -> list[str]:
+        """The interpreter that runs the executable."""
+        return self.__interpreter
 
     @directory.setter
     def directory(self, directory: PathLike):
@@ -237,6 +286,17 @@ class Manager:
     @filetype.setter
     def filetype(self, filetype: str):
         self.__filetype = filetype
+
+    @interpreter.setter
+    def interpreter(self, interpreter: str | list[str] | None):
+        if interpreter is None or len(interpreter) == 0:
+            self.__interpreter = []
+        elif type(interpreter) == str:
+            self.__interpreter = interpreter.split()
+        elif type(interpreter) == list:
+            self.__interpreter = interpreter
+        else:
+            raise Exception("interpreter must be None, a string or a list of strings")
 
     def create(
         self,
@@ -315,24 +375,7 @@ class Manager:
                     json.dump(js, f, sort_keys=True, ensure_ascii=True, indent=4)
             # Run the code to create output file
             try:
-                # Check if the simulation is a restart
-                if n == 0:
-                    process = subprocess.run(
-                        [self.__executable, self.jsonfile(js), ncfile],
-                        check=True,
-                        capture_output=True,
-                    )
-                    if stdout == "display":
-                        print(process.stdout)
-                else:
-                    previous_ncfile = self.outfile(js, n - 1)
-                    process = subprocess.run(
-                        [self.__executable, self.jsonfile(js), ncfile, previous_ncfile],
-                        check=True,
-                        capture_output=True,
-                    )
-                    if stdout == "display":
-                        print(process.stdout)
+                self.__execute(js, ncfile, n, stdout)
             except subprocess.CalledProcessError as e:
                 # clean up entry and escalate exception
                 if os.path.isfile(ncfile):
@@ -345,6 +388,24 @@ class Manager:
                     raise e
 
             return ncfile
+
+    def __execute(self, js, ncfile, n=0, stdout="ignore"):
+        """Helper function to run the executable with the correct arguments
+
+        This is used in create to keep the code cleaner and reduce identation depth.
+        """
+        if self.__executable is None:
+            raise Exception("Executable not set! Set it with m.executable = '...'")
+
+        command = self.__interpreter + [self.__executable, self.jsonfile(js), ncfile]
+
+        # Check if the simulation is a restart
+        if n > 0:
+            previous_ncfile = self.outfile(js, n - 1)
+            command.append(previous_ncfile)
+        process = subprocess.run(command, check=True, capture_output=True)
+        if stdout == "display":
+            print(process.stdout)
 
     def recreate(
         self,

--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -29,8 +29,11 @@ class Repeater:
     """
 
     def __init__(
-        self, executable="./execute.sh", inputfile="temp.json", outputfile="temp.nc",
-        interpreter: str | list[str] | None = None
+        self,
+        executable="./execute.sh",
+        inputfile="temp.json",
+        outputfile="temp.nc",
+        interpreter: str | list[str] | None = None,
     ):
         """Set the executable and files to use in the run method"""
         self.executable = executable
@@ -110,7 +113,7 @@ class Repeater:
                     *self.__interpreter,
                     self.__executable,
                     self.__inputfile,
-                    self.__outputfile
+                    self.__outputfile,
                 ],
                 check=True,
                 capture_output=True,
@@ -403,11 +406,7 @@ class Manager:
         if self.__executable is None:
             raise Exception("Executable not set! Set it with m.executable = '...'")
 
-        command = [
-                    *self.__interpreter,
-                    self.__executable,
-                    self.jsonfile(js),
-                    ncfile]
+        command = [*self.__interpreter, self.__executable, self.jsonfile(js), ncfile]
 
         # Check if the simulation is a restart
         if n > 0:
@@ -676,37 +675,21 @@ class Manager:
             )
         if hashid in registry:
             if name != registry[hashid]:
-                raise Exception(
-                    "The name '"
-                    + name
-                    + "' cannot be used! The\
- input file is already known under the name '"
-                    + registry[hashid]
-                    + "'. Use\
- delete to clear the registry."
-                )
+                raise Exception("The name '" + name + "' cannot be used! The\
+ input file is already known under the name '" + registry[hashid] + "'. Use\
+ delete to clear the registry.")
         else:
             jsonfile = os.path.join(self.__directory, hashid + ".json")
             if os.path.isfile(jsonfile):
-                raise Exception(
-                    "The name '"
-                    + name
-                    + "' cannot be used! The\
- input file is already known under the name '"
-                    + jsonfile
-                    + "'. Use\
- delete to clear the registry."
-                )
+                raise Exception("The name '" + name + "' cannot be used! The\
+ input file is already known under the name '" + jsonfile + "'. Use\
+ delete to clear the registry.")
 
             registry[hashid] = name
         for key, value in registry.items():
             if (value == name) and key != hashid:
-                raise Exception(
-                    "The name '"
-                    + name
-                    + "' is already in use\
- for a different simulation. Choose a different name!"
-                )
+                raise Exception("The name '" + name + "' is already in use\
+ for a different simulation. Choose a different name!")
 
         self.set_registry(registry)
 

--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -30,7 +30,7 @@ class Repeater:
 
     def __init__(
         self, executable="./execute.sh", inputfile="temp.json", outputfile="temp.nc",
-        interpreter: str | list[str] = None
+        interpreter: str | list[str] | None = None
     ):
         """Set the executable and files to use in the run method"""
         self.executable = executable
@@ -38,9 +38,9 @@ class Repeater:
         self.outputfile = outputfile
         if interpreter is None or len(interpreter) == 0:
             self.interpreter = []
-        elif type(interpreter) == str:
+        elif type(interpreter) is str:
             self.interpreter = interpreter.split()
-        elif type(interpreter) == list:
+        elif type(interpreter) is list:
             self.interpreter = interpreter
         else:
             raise Exception("interpreter must be None, a string or a list of strings")
@@ -56,7 +56,7 @@ class Repeater:
     @property
     def outputfile(self):
         return self.__outputfile
-    
+
     @property
     def interpreter(self):
         return self.__interpreter
@@ -77,9 +77,9 @@ class Repeater:
     def interpreter(self, interpreter):
         if interpreter is None or len(interpreter) == 0:
             self.__interpreter = []
-        elif type(interpreter) == str:
+        elif type(interpreter) is str:
             self.__interpreter = interpreter.split()
-        elif type(interpreter) == list:
+        elif type(interpreter) is list:
             self.__interpreter = interpreter
         else:
             raise Exception("interpreter must be None, a string or a list of strings")
@@ -106,7 +106,12 @@ class Repeater:
             json.dump(js, f, sort_keys=True, ensure_ascii=True, indent=4)
         try:
             process = subprocess.run(
-                self.__interpreter + [self.__executable, self.__inputfile, self.__outputfile],
+                [
+                    *self.__interpreter,
+                    self.__executable,
+                    self.__inputfile,
+                    self.__outputfile
+                ],
                 check=True,
                 capture_output=True,
             )
@@ -204,33 +209,34 @@ class Manager:
             file extension of the output files
         executable:
             The executable that generates the data.
-            executable is called using subprocess.run([interpreter, executable, 
+            executable is called using subprocess.run([interpreter, executable,
             directory/hashid.json, directory/hashid.filetype],...) with
-            2 arguments - a json file as input (do not change the input else the file is not
-            recognized any more) and one output file (that executable needs to
+            2 arguments - a json file as input (do not change the input else the file
+            is not recognized any more) and one output file (that executable needs to
             generate) (if your code does not take json as input you can for example
             parse json in bash using jq)
         interpreter:
             (optional) If your executable is not directly runnable but needs to be
             called via an interpreter (e.g. python, julia, R, powershell, etc.) you can
-            specify the interpreter here as a whitespace separated string or list of strings.
-            For example if your executable is a python script you can set interpreter="python.exe"
-            and the code will be called as subprocess.run(["python.exe", executable, ...],...)
-            You can also include interpreter arguments here. For example to run in a specific 
-            conda environment, set interpreter=["conda", "run", "-n", "myenv"]
-            or interpreter="conda run -n myenv" and the code will be called as
-            subprocess.run(["conda", "run", "-n", "myenv", executable, ...],...)
+            specify the interpreter here as a whitespace separated string or list of
+            strings. For example if your executable is a python script you can set
+            interpreter="python.exe" and the code will be called as
+            subprocess.run(["python.exe", executable, ...],...)
+            You can also include interpreter arguments here. For example to run in
+            a specific conda environment, set interpreter=["conda", "run", "-n",
+            "myenv"] or interpreter="conda run -n myenv" and the code will be called
+            as subprocess.run(["conda", "run", "-n", "myenv", executable, ...],...)
         """
         self.directory = directory
         os.makedirs(self.__directory, exist_ok=True)
         self.filetype = filetype
         self.executable = executable
-                
+
         if interpreter is None or len(interpreter) == 0:
             self.interpreter = []
-        elif type(interpreter) == str:
+        elif type(interpreter) is str:
             self.interpreter = interpreter.split()
-        elif type(interpreter) == list:
+        elif type(interpreter) is list:
             self.interpreter = interpreter
         else:
             raise Exception("interpreter must be None, a string or a list of strings")
@@ -268,7 +274,7 @@ class Manager:
     def filetype(self) -> str:
         """File extension of the output files"""
         return self.__filetype
-    
+
     @property
     def interpreter(self) -> list[str]:
         """The interpreter that runs the executable."""
@@ -291,9 +297,9 @@ class Manager:
     def interpreter(self, interpreter: str | list[str] | None):
         if interpreter is None or len(interpreter) == 0:
             self.__interpreter = []
-        elif type(interpreter) == str:
+        elif type(interpreter) is str:
             self.__interpreter = interpreter.split()
-        elif type(interpreter) == list:
+        elif type(interpreter) is list:
             self.__interpreter = interpreter
         else:
             raise Exception("interpreter must be None, a string or a list of strings")
@@ -397,7 +403,11 @@ class Manager:
         if self.__executable is None:
             raise Exception("Executable not set! Set it with m.executable = '...'")
 
-        command = self.__interpreter + [self.__executable, self.jsonfile(js), ncfile]
+        command = [
+                    *self.__interpreter,
+                    self.__executable,
+                    self.jsonfile(js),
+                    ncfile]
 
         # Check if the simulation is a restart
         if n > 0:

--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -30,23 +30,14 @@ class Repeater:
 
     def __init__(
         self,
-        executable="./execute.sh",
+        executable: str | list[str] = "./execute.sh",
         inputfile="temp.json",
         outputfile="temp.nc",
-        interpreter: str | list[str] | None = None,
     ):
         """Set the executable and files to use in the run method"""
-        self.executable = executable
         self.inputfile = inputfile
         self.outputfile = outputfile
-        if interpreter is None or len(interpreter) == 0:
-            self.interpreter = []
-        elif type(interpreter) is str:
-            self.interpreter = interpreter.split()
-        elif type(interpreter) is list:
-            self.interpreter = interpreter
-        else:
-            raise Exception("interpreter must be None, a string or a list of strings")
+        self.executable = executable
 
     @property
     def executable(self):
@@ -60,13 +51,16 @@ class Repeater:
     def outputfile(self):
         return self.__outputfile
 
-    @property
-    def interpreter(self):
-        return self.__interpreter
-
     @executable.setter
     def executable(self, executable):
-        self.__executable = executable
+        if executable is None or type(executable) not in [str, list]:
+            raise Exception("Executable must be given as a string or list of strings")
+        elif len(executable) == 0:
+            raise Exception("Executable cannot be empty string or list")
+        elif type(executable) is str:
+            self.__executable = [executable]
+        elif type(executable) is list:
+            self.__executable = executable
 
     @inputfile.setter
     def inputfile(self, inputfile):
@@ -75,17 +69,6 @@ class Repeater:
     @outputfile.setter
     def outputfile(self, outputfile):
         self.__outputfile = outputfile
-
-    @interpreter.setter
-    def interpreter(self, interpreter):
-        if interpreter is None or len(interpreter) == 0:
-            self.__interpreter = []
-        elif type(interpreter) is str:
-            self.__interpreter = interpreter.split()
-        elif type(interpreter) is list:
-            self.__interpreter = interpreter
-        else:
-            raise Exception("interpreter must be None, a string or a list of strings")
 
     def run(self, js: JSONDict, error: str = "display", stdout: str = "ignore"):
         """Write inputfile and then run a simulation
@@ -110,8 +93,7 @@ class Repeater:
         try:
             process = subprocess.run(
                 [
-                    *self.__interpreter,
-                    self.__executable,
+                    *self.__executable,
                     self.__inputfile,
                     self.__outputfile,
                 ],
@@ -178,8 +160,7 @@ class Manager:
         self,
         directory: PathLike = "./data",
         filetype: str = "nc",
-        executable: str = "./execute.sh",
-        interpreter: str | list[str] | None = None,
+        executable: str | list[str] = "./execute.sh",
     ):
         """Init the Manager class
 
@@ -192,8 +173,7 @@ class Manager:
 
             subprocess.run(
                 [
-                    interpreter,
-                    executable,
+                    *executable,
                     directory/hashid.json,
                     directory/hashid0xN.filetype,
                     directory/hashid0x(N-1).filetype,
@@ -211,38 +191,25 @@ class Manager:
         filetype:
             file extension of the output files
         executable:
-            The executable that generates the data.
-            executable is called using subprocess.run([interpreter, executable,
+            The executable that generates the data. Can be a string or list of strings.
+            Since executable is passed to subprocess.run, it can be a command with
+            arguments. If your code is an executable script or single command, this
+            can be passed just as a string (e.g. "./execute.sh" or "cp"). If your code
+            needs to be run with an interpreter or needs additional arguments (e.g.
+            "python script.py", "ls -l"), then you must pass the executable as a list
+            of strings (e.g. ["python", "script.py"], ["ls", "-l"]). Same as it would
+            be given to subprocess.run.
+            executable is called using subprocess.run(executable + [
             directory/hashid.json, directory/hashid.filetype],...) with
-            2 arguments - a json file as input (do not change the input else the file
+            a json file as input (do not change the input else the file
             is not recognized any more) and one output file (that executable needs to
             generate) (if your code does not take json as input you can for example
             parse json in bash using jq)
-        interpreter:
-            (optional) If your executable is not directly runnable but needs to be
-            called via an interpreter (e.g. python, julia, R, powershell, etc.) you can
-            specify the interpreter here as a whitespace separated string or list of
-            strings. For example if your executable is a python script you can set
-            interpreter="python.exe" and the code will be called as
-            subprocess.run(["python.exe", executable, ...],...)
-            You can also include interpreter arguments here. For example to run in
-            a specific conda environment, set interpreter=["conda", "run", "-n",
-            "myenv"] or interpreter="conda run -n myenv" and the code will be called
-            as subprocess.run(["conda", "run", "-n", "myenv", executable, ...],...)
         """
         self.directory = directory
         os.makedirs(self.__directory, exist_ok=True)
         self.filetype = filetype
         self.executable = executable
-
-        if interpreter is None or len(interpreter) == 0:
-            self.interpreter = []
-        elif type(interpreter) is str:
-            self.interpreter = interpreter.split()
-        elif type(interpreter) is list:
-            self.interpreter = interpreter
-        else:
-            raise Exception("interpreter must be None, a string or a list of strings")
 
     @property
     def directory(self) -> PathLike:
@@ -253,10 +220,10 @@ class Manager:
         return self.__directory
 
     @property
-    def executable(self) -> str:
+    def executable(self) -> list[str]:
         """The executable that generates the data.
 
-        The create method calls subprocess.run([interpreter, executable,
+        The create method calls subprocess.run([*executable,
         directory/hashid.json, directory/hashid.filetype],...) that is it must
         take 2 arguments - a json file as input (do not change the input else
         the file is not recognized any more) and one output file (that
@@ -267,7 +234,7 @@ class Manager:
         ----------------------------------
         If you intend to use the restart option (by passing a simulation number
         n>0 to create), the executable is called with
-        subprocess.run([interpreter, executable, directory/hashid.json,
+        subprocess.run([*executable, directory/hashid.json,
         directory/hashid0xN.filetype, directory/hashid0x(N-1).filetype],...)
         that is it must take a third argument (the previous simulation)
         """
@@ -278,34 +245,25 @@ class Manager:
         """File extension of the output files"""
         return self.__filetype
 
-    @property
-    def interpreter(self) -> list[str]:
-        """The interpreter that runs the executable."""
-        return self.__interpreter
-
     @directory.setter
     def directory(self, directory: PathLike):
         self.__directory = directory
         os.makedirs(self.__directory, exist_ok=True)
 
     @executable.setter
-    def executable(self, executable: str):
-        self.__executable = executable
+    def executable(self, executable: str | list[str]):
+        if executable is None or type(executable) not in [str, list]:
+            raise Exception("Executable must be given as a string or list of strings")
+        if len(executable) == 0:
+            raise Exception("Executable cannot be empty string or list")
+        elif type(executable) is str:
+            self.__executable = [executable]
+        elif type(executable) is list:
+            self.__executable = executable
 
     @filetype.setter
     def filetype(self, filetype: str):
         self.__filetype = filetype
-
-    @interpreter.setter
-    def interpreter(self, interpreter: str | list[str] | None):
-        if interpreter is None or len(interpreter) == 0:
-            self.__interpreter = []
-        elif type(interpreter) is str:
-            self.__interpreter = interpreter.split()
-        elif type(interpreter) is list:
-            self.__interpreter = interpreter
-        else:
-            raise Exception("interpreter must be None, a string or a list of strings")
 
     def create(
         self,
@@ -406,7 +364,7 @@ class Manager:
         if self.__executable is None:
             raise Exception("Executable not set! Set it with m.executable = '...'")
 
-        command = [*self.__interpreter, self.__executable, self.jsonfile(js), ncfile]
+        command = [*self.__executable, self.jsonfile(js), ncfile]
 
         # Check if the simulation is a restart
         if n > 0:

--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -35,9 +35,9 @@ class Repeater:
         outputfile="temp.nc",
     ):
         """Set the executable and files to use in the run method"""
+        self.executable = executable
         self.inputfile = inputfile
         self.outputfile = outputfile
-        self.executable = executable
 
     @property
     def executable(self):
@@ -57,9 +57,7 @@ class Repeater:
             raise Exception("Executable must be given as a string or list of strings")
         elif len(executable) == 0:
             raise Exception("Executable cannot be empty string or list")
-        elif type(executable) is str:
-            self.__executable = [executable]
-        elif type(executable) is list:
+        elif type(executable) is str or type(executable) is list:
             self.__executable = executable
 
     @inputfile.setter
@@ -91,15 +89,18 @@ class Repeater:
         with open(self.inputfile, "w") as f:
             json.dump(js, f, sort_keys=True, ensure_ascii=True, indent=4)
         try:
+            command = []
+            if type(self.__executable) is str:
+                command = [self.__executable, self.inputfile, self.outputfile]
+            elif type(self.__executable) is list:
+                command = [*self.__executable, self.inputfile, self.outputfile]
+
             process = subprocess.run(
-                [
-                    *self.__executable,
-                    self.__inputfile,
-                    self.__outputfile,
-                ],
+                command,
                 check=True,
                 capture_output=True,
             )
+
             if stdout == "display":
                 print(process.stdout)
         except subprocess.CalledProcessError as e:
@@ -173,7 +174,7 @@ class Manager:
 
             subprocess.run(
                 [
-                    *executable,
+                    executable,
                     directory/hashid.json,
                     directory/hashid0xN.filetype,
                     directory/hashid0x(N-1).filetype,
@@ -199,7 +200,7 @@ class Manager:
             "python script.py", "ls -l"), then you must pass the executable as a list
             of strings (e.g. ["python", "script.py"], ["ls", "-l"]). Same as it would
             be given to subprocess.run.
-            executable is called using subprocess.run(executable + [
+            executable is called using subprocess.run([executable,
             directory/hashid.json, directory/hashid.filetype],...) with
             a json file as input (do not change the input else the file
             is not recognized any more) and one output file (that executable needs to
@@ -223,7 +224,7 @@ class Manager:
     def executable(self) -> list[str]:
         """The executable that generates the data.
 
-        The create method calls subprocess.run([*executable,
+        The create method calls subprocess.run([executable,
         directory/hashid.json, directory/hashid.filetype],...) that is it must
         take 2 arguments - a json file as input (do not change the input else
         the file is not recognized any more) and one output file (that
@@ -256,9 +257,7 @@ class Manager:
             raise Exception("Executable must be given as a string or list of strings")
         if len(executable) == 0:
             raise Exception("Executable cannot be empty string or list")
-        elif type(executable) is str:
-            self.__executable = [executable]
-        elif type(executable) is list:
+        elif type(executable) is str or type(executable) is list:
             self.__executable = executable
 
     @filetype.setter
@@ -364,7 +363,11 @@ class Manager:
         if self.__executable is None:
             raise Exception("Executable not set! Set it with m.executable = '...'")
 
-        command = [*self.__executable, self.jsonfile(js), ncfile]
+        command = []
+        if type(self.__executable) is str:
+            command = [self.__executable, self.jsonfile(js), ncfile]
+        elif type(self.__executable) is list:
+            command = [*self.__executable, self.jsonfile(js), ncfile]
 
         # Check if the simulation is a restart
         if n > 0:

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -30,9 +30,9 @@ def test_creation():
 def test_creation_with_interpreter():
     print("TEST CREATION WITH INTERPRETER")
     executable = (
-        'import sys; import subprocess; '
-        'subprocess.run(["cp", sys.argv[1], sys.argv[2]])'
-        )
+        "import sys; import subprocess; "
+        "subprocess.run(['cp', sys.argv[1], sys.argv[2]])"
+    )
     m = sim.Manager(
         directory="creation_interpreter_test",
         executable=executable,
@@ -127,9 +127,9 @@ def test_repeater_with_interpreter():
     print("TEST REPEATER WITH INTERPRETER")
     os.makedirs("temp_repeater_interpreter", exist_ok=True)
     executable = (
-            'import sys; import subprocess; '
-            'subprocess.run(["touch", sys.argv[1], sys.argv[2]])'
-            )
+        "import sys; import subprocess; "
+        "subprocess.run(['touch', sys.argv[1], sys.argv[2]])"
+    )
     m = sim.Repeater(
         executable,
         "temp_repeater_interpreter/temp.json",
@@ -141,9 +141,9 @@ def test_repeater_with_interpreter():
     assert os.path.isfile("temp_repeater_interpreter/temp.json")
     assert os.path.isfile("temp_repeater_interpreter/temp.nc")
     m.executable = (
-            'import sys; import subprocess; '
-            'subprocess.run(["echo", sys.argv[1], sys.argv[2]])'
-            )
+        "import sys; import subprocess; "
+        "subprocess.run(['echo', sys.argv[1], sys.argv[2]])"
+    )
     m.run(inputdata, error="display", stdout="display")
     m.clean()
     assert not os.path.isfile("temp_repeater_interpreter/temp.json")

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -1,5 +1,7 @@
 import os.path
 
+import pytest
+
 import simplesimdb as sim
 
 # Run with pytest -s . to see stdout output
@@ -17,7 +19,7 @@ def test_creation():
     print("TEST CREATION")
     m = sim.Manager(directory="creation_test", executable="cp", filetype="json")
     assert m.directory == "creation_test"
-    assert m.executable == ["cp"]
+    assert m.executable == "cp"
     assert m.filetype == "json"
     inputdata = {"Hello": "World"}
     m.create(inputdata)
@@ -150,3 +152,35 @@ def test_repeater_with_interpreter():
     temp_folder_empty = not os.listdir("temp_repeater_interpreter")
     if temp_folder_exists and temp_folder_empty:
         os.rmdir("temp_repeater_interpreter")
+
+
+def test_executable_validation():
+    print("TEST EXECUTABLE VALIDATION")
+    match = "Executable must be given as a string or list of strings"
+    with pytest.raises(Exception, match=match):
+        sim.Manager(
+            directory="executable_validation_test", executable=123, filetype="json"
+        )
+
+    match = "Executable cannot be empty string or list"
+    with pytest.raises(Exception, match=match):
+        sim.Manager(
+            directory="executable_validation_test", executable="", filetype="json"
+        )
+
+    with pytest.raises(Exception, match=match):
+        sim.Manager(
+            directory="executable_validation_test", executable=[], filetype="json"
+        )
+
+    m = sim.Manager(
+        directory="executable_validation_test", executable="echo", filetype="json"
+    )
+
+    assert m.executable == "echo"
+    m.executable = "ls -l"
+    assert m.executable == "ls -l"
+    m.executable = ["ls", "-l"]
+    assert m.executable == ["ls", "-l"]
+    m.delete_all()
+    assert not os.path.isdir(m.directory)

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -26,6 +26,26 @@ def test_creation():
     m.delete_all()
     assert not os.path.isdir(m.directory)
 
+def test_creation_with_interpreter():
+    print("TEST CREATION WITH INTERPRETER")
+    executable = 'import sys; import os; os.system("cp " + sys.argv[1] + " " + sys.argv[2])'
+    m = sim.Manager(
+        directory="creation_interpreter_test",
+        executable=executable,
+        filetype="json",
+        interpreter="python -c",
+    )
+    assert m.directory == "creation_interpreter_test"
+    assert m.executable == executable
+    assert m.filetype == "json"
+    assert m.interpreter == ["python", "-c"]
+    inputdata = {"Hello": "World"}
+    m.create(inputdata, 0)
+    content = m.table()
+    assert content == [inputdata]
+    m.delete_all()
+    assert not os.path.isdir(m.directory)
+
 
 def test_selection():
     print("TEST SELECTION")
@@ -82,13 +102,38 @@ def test_named_creation():
 
 def test_repeater():
     print("TEST REPEATER")
-    m = sim.Repeater("touch", "temp.json", "temp.nc")
+    os.makedirs("temp_repeater", exist_ok=True)
+    m = sim.Repeater("touch", "temp_repeater/temp.json", "temp_repeater/temp.nc")
     inputdata = {"Hello": "World"}
     m.run(inputdata, error="display", stdout="display")
-    assert os.path.isfile("temp.json")
-    assert os.path.isfile("temp.nc")
+    assert os.path.isfile("temp_repeater/temp.json")
+    assert os.path.isfile("temp_repeater/temp.nc")
     m.executable = "echo"
     m.run(inputdata, error="display", stdout="display")
     m.clean()
-    assert not os.path.isfile("temp.json")
-    assert not os.path.isfile("temp.nc")
+    assert not os.path.isfile("temp_repeater/temp.json")
+    assert not os.path.isfile("temp_repeater/temp.nc")
+    if os.path.isdir("temp_repeater") and not os.listdir("temp_repeater"):
+        os.rmdir("temp_repeater")
+
+def test_repeater_with_interpreter():
+    print("TEST REPEATER WITH INTERPRETER")
+    os.makedirs("temp_repeater_interpreter", exist_ok=True)
+    executable = 'import sys; import os; os.system("touch " + sys.argv[1] + " " + sys.argv[2])'
+    m = sim.Repeater(
+        executable,
+        "temp_repeater_interpreter/temp.json",
+        "temp_repeater_interpreter/temp.nc",
+        interpreter="python -c",
+    )
+    inputdata = {"Hello": "World"}
+    m.run(inputdata, error="display", stdout="display")
+    assert os.path.isfile("temp_repeater_interpreter/temp.json")
+    assert os.path.isfile("temp_repeater_interpreter/temp.nc")
+    m.executable = 'import sys; import os; os.system("echo " + sys.argv[1] + " " + sys.argv[2])'
+    m.run(inputdata, error="display", stdout="display")
+    m.clean()
+    assert not os.path.isfile("temp_repeater_interpreter/temp.json")
+    assert not os.path.isfile("temp_repeater_interpreter/temp.nc")
+    if os.path.isdir("temp_repeater_interpreter") and not os.listdir("temp_repeater_interpreter"):
+        os.rmdir("temp_repeater_interpreter")

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -26,9 +26,13 @@ def test_creation():
     m.delete_all()
     assert not os.path.isdir(m.directory)
 
+
 def test_creation_with_interpreter():
     print("TEST CREATION WITH INTERPRETER")
-    executable = 'import sys; import os; os.system("cp " + sys.argv[1] + " " + sys.argv[2])'
+    executable = (
+        'import sys; import subprocess; '
+        'subprocess.run(["cp", sys.argv[1], sys.argv[2]])'
+        )
     m = sim.Manager(
         directory="creation_interpreter_test",
         executable=executable,
@@ -113,13 +117,19 @@ def test_repeater():
     m.clean()
     assert not os.path.isfile("temp_repeater/temp.json")
     assert not os.path.isfile("temp_repeater/temp.nc")
-    if os.path.isdir("temp_repeater") and not os.listdir("temp_repeater"):
+    temp_folder_exists = os.path.isdir("temp_repeater")
+    temp_folder_empty = not os.listdir("temp_repeater")
+    if temp_folder_exists and temp_folder_empty:
         os.rmdir("temp_repeater")
+
 
 def test_repeater_with_interpreter():
     print("TEST REPEATER WITH INTERPRETER")
     os.makedirs("temp_repeater_interpreter", exist_ok=True)
-    executable = 'import sys; import os; os.system("touch " + sys.argv[1] + " " + sys.argv[2])'
+    executable = (
+            'import sys; import subprocess; '
+            'subprocess.run(["touch", sys.argv[1], sys.argv[2]])'
+            )
     m = sim.Repeater(
         executable,
         "temp_repeater_interpreter/temp.json",
@@ -130,10 +140,15 @@ def test_repeater_with_interpreter():
     m.run(inputdata, error="display", stdout="display")
     assert os.path.isfile("temp_repeater_interpreter/temp.json")
     assert os.path.isfile("temp_repeater_interpreter/temp.nc")
-    m.executable = 'import sys; import os; os.system("echo " + sys.argv[1] + " " + sys.argv[2])'
+    m.executable = (
+            'import sys; import subprocess; '
+            'subprocess.run(["echo", sys.argv[1], sys.argv[2]])'
+            )
     m.run(inputdata, error="display", stdout="display")
     m.clean()
     assert not os.path.isfile("temp_repeater_interpreter/temp.json")
     assert not os.path.isfile("temp_repeater_interpreter/temp.nc")
-    if os.path.isdir("temp_repeater_interpreter") and not os.listdir("temp_repeater_interpreter"):
+    temp_folder_exists = os.path.isdir("temp_repeater_interpreter")
+    temp_folder_empty = not os.listdir("temp_repeater_interpreter")
+    if temp_folder_exists and temp_folder_empty:
         os.rmdir("temp_repeater_interpreter")

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -17,7 +17,7 @@ def test_creation():
     print("TEST CREATION")
     m = sim.Manager(directory="creation_test", executable="cp", filetype="json")
     assert m.directory == "creation_test"
-    assert m.executable == "cp"
+    assert m.executable == ["cp"]
     assert m.filetype == "json"
     inputdata = {"Hello": "World"}
     m.create(inputdata)
@@ -29,20 +29,18 @@ def test_creation():
 
 def test_creation_with_interpreter():
     print("TEST CREATION WITH INTERPRETER")
-    executable = (
+    script = (
         "import sys; import subprocess; "
         "subprocess.run(['cp', sys.argv[1], sys.argv[2]])"
     )
     m = sim.Manager(
         directory="creation_interpreter_test",
-        executable=executable,
+        executable=["python", "-c", script],
         filetype="json",
-        interpreter="python -c",
     )
     assert m.directory == "creation_interpreter_test"
-    assert m.executable == executable
+    assert m.executable == ["python", "-c", script]
     assert m.filetype == "json"
-    assert m.interpreter == ["python", "-c"]
     inputdata = {"Hello": "World"}
     m.create(inputdata, 0)
     content = m.table()
@@ -126,24 +124,24 @@ def test_repeater():
 def test_repeater_with_interpreter():
     print("TEST REPEATER WITH INTERPRETER")
     os.makedirs("temp_repeater_interpreter", exist_ok=True)
-    executable = (
+    script = (
         "import sys; import subprocess; "
         "subprocess.run(['touch', sys.argv[1], sys.argv[2]])"
     )
     m = sim.Repeater(
-        executable,
+        ["python", "-c", script],
         "temp_repeater_interpreter/temp.json",
         "temp_repeater_interpreter/temp.nc",
-        interpreter="python -c",
     )
     inputdata = {"Hello": "World"}
     m.run(inputdata, error="display", stdout="display")
     assert os.path.isfile("temp_repeater_interpreter/temp.json")
     assert os.path.isfile("temp_repeater_interpreter/temp.nc")
-    m.executable = (
+    script = (
         "import sys; import subprocess; "
         "subprocess.run(['echo', sys.argv[1], sys.argv[2]])"
     )
+    m.executable = ["python", "-c", script]
     m.run(inputdata, error="display", stdout="display")
     m.clean()
     assert not os.path.isfile("temp_repeater_interpreter/temp.json")


### PR DESCRIPTION
This pull request adds support for specifying an interpreter (such as Python, Julia, or R) when running executables in both the `Repeater` and `Manager` classes. This feature allows users to run scripts that require an interpreter, which is important for Windows users as they need to specify an interpreter to run PowerShell or bash commands, with flexible specification as either a string or list of arguments. The documentation and tests are updated to cover this new functionality, and internal code is refactored for clarity and maintainability.

**Interpreter support for executables:**

* Added an `interpreter` parameter to both `Repeater` and `Manager`, allowing executables to be run through an interpreter (e.g., `python`, `conda run ...`). This can be specified as a string or a list of strings, and is prepended to the command used in `subprocess.run`. [[1]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24L32-R46) [[2]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24R174) [[3]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24L181-R237)
* Implemented getter and setter methods for the `interpreter` property in both classes, with validation to ensure correct types. [[1]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24R60-R63) [[2]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24R76-R86) [[3]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24R272-R276) [[4]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24R290-R300)
* Updated the logic in `run` (Repeater) and `create` (Manager) to use the interpreter when launching the executable. This includes creating private function `__execute` as a helper to execute the executable. [[1]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24L85-R109) [[2]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24R187) [[3]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24L318-R378) [[4]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24R392-R409)

**Documentation updates:**

* Expanded docstrings for `Manager` to document the new `interpreter` argument, how to use it, and provided usage examples. [[1]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24L181-R237) [[2]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24L206-R250) [[3]](diffhunk://#diff-bdcf7842ef59715a6b24f7f5cef089d67a7ad31eb98167682f1d45a058a41e24L217-R261)

**Testing improvements:**

* Added new tests to verify that both `Manager` and `Repeater` work correctly with an interpreter. [[1]](diffhunk://#diff-cde49e23f2bc70f08c83299b936d25055a9175037aa4d96378728b12cac90c3cR29-R48) [[2]](diffhunk://#diff-cde49e23f2bc70f08c83299b936d25055a9175037aa4d96378728b12cac90c3cL85-R139)
* Updated existing tests to avoid side effects and ensure proper cleanup of temporary files and directories.

**Limitations**

* Tests do not work on Windows, this needs further changes.
*  If the parameter `interpreter` is passed as a string, any whitespace will be used for splitting the string. This creates problems when trying to set the interpreter using a path containing whitespaces. This is evident on Windows, as git bash lives in `C:\Program Files\Git\usr\bin\bash.exe`.