### PR TITLE
Fix tests on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,12 @@ on: [push, pull_request]
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -29,12 +29,21 @@ class Repeater:
     """
 
     def __init__(
-        self, executable="./execute.sh", inputfile="temp.json", outputfile="temp.nc"
+        self, executable="./execute.sh", inputfile="temp.json", outputfile="temp.nc",
+        interpreter: str | list[str] = None
     ):
         """Set the executable and files to use in the run method"""
         self.executable = executable
         self.inputfile = inputfile
         self.outputfile = outputfile
+        if interpreter is None or len(interpreter) == 0:
+            self.interpreter = []
+        elif type(interpreter) == str:
+            self.interpreter = interpreter.split()
+        elif type(interpreter) == list:
+            self.interpreter = interpreter
+        else:
+            raise Exception("interpreter must be None, a string or a list of strings")
 
     @property
     def executable(self):
@@ -47,6 +56,10 @@ class Repeater:
     @property
     def outputfile(self):
         return self.__outputfile
+    
+    @property
+    def interpreter(self):
+        return self.__interpreter
 
     @executable.setter
     def executable(self, executable):
@@ -59,6 +72,17 @@ class Repeater:
     @outputfile.setter
     def outputfile(self, outputfile):
         self.__outputfile = outputfile
+
+    @interpreter.setter
+    def interpreter(self, interpreter):
+        if interpreter is None or len(interpreter) == 0:
+            self.__interpreter = []
+        elif type(interpreter) == str:
+            self.__interpreter = interpreter.split()
+        elif type(interpreter) == list:
+            self.__interpreter = interpreter
+        else:
+            raise Exception("interpreter must be None, a string or a list of strings")
 
     def run(self, js: JSONDict, error: str = "display", stdout: str = "ignore"):
         """Write inputfile and then run a simulation
@@ -82,7 +106,7 @@ class Repeater:
             json.dump(js, f, sort_keys=True, ensure_ascii=True, indent=4)
         try:
             process = subprocess.run(
-                [self.__executable, self.__inputfile, self.__outputfile],
+                self.__interpreter + [self.__executable, self.__inputfile, self.__outputfile],
                 check=True,
                 capture_output=True,
             )
@@ -147,6 +171,7 @@ class Manager:
         directory: PathLike = "./data",
         filetype: str = "nc",
         executable: str = "./execute.sh",
+        interpreter: str | list[str] | None = None,
     ):
         """Init the Manager class
 
@@ -159,6 +184,7 @@ class Manager:
 
             subprocess.run(
                 [
+                    interpreter,
                     executable,
                     directory/hashid.json,
                     directory/hashid0xN.filetype,
@@ -178,18 +204,36 @@ class Manager:
             file extension of the output files
         executable:
             The executable that generates the data.
-            executable is called using subprocess.run([executable,
-            directory/hashid.json, directory/hashid.filetype],...) with 2 arguments
-            - a json file as input (do not change the input else the file is not
+            executable is called using subprocess.run([interpreter, executable, 
+            directory/hashid.json, directory/hashid.filetype],...) with
+            2 arguments - a json file as input (do not change the input else the file is not
             recognized any more) and one output file (that executable needs to
             generate) (if your code does not take json as input you can for example
             parse json in bash using jq)
-
+        interpreter:
+            (optional) If your executable is not directly runnable but needs to be
+            called via an interpreter (e.g. python, julia, R, powershell, etc.) you can
+            specify the interpreter here as a whitespace separated string or list of strings.
+            For example if your executable is a python script you can set interpreter="python.exe"
+            and the code will be called as subprocess.run(["python.exe", executable, ...],...)
+            You can also include interpreter arguments here. For example to run in a specific 
+            conda environment, set interpreter=["conda", "run", "-n", "myenv"]
+            or interpreter="conda run -n myenv" and the code will be called as
+            subprocess.run(["conda", "run", "-n", "myenv", executable, ...],...)
         """
         self.directory = directory
         os.makedirs(self.__directory, exist_ok=True)
         self.filetype = filetype
         self.executable = executable
+                
+        if interpreter is None or len(interpreter) == 0:
+            self.interpreter = []
+        elif type(interpreter) == str:
+            self.interpreter = interpreter.split()
+        elif type(interpreter) == list:
+            self.interpreter = interpreter
+        else:
+            raise Exception("interpreter must be None, a string or a list of strings")
 
     @property
     def directory(self) -> PathLike:
@@ -203,7 +247,7 @@ class Manager:
     def executable(self) -> str:
         """The executable that generates the data.
 
-        The create method calls subprocess.run([executable,
+        The create method calls subprocess.run([interpreter, executable,
         directory/hashid.json, directory/hashid.filetype],...) that is it must
         take 2 arguments - a json file as input (do not change the input else
         the file is not recognized any more) and one output file (that
@@ -214,7 +258,7 @@ class Manager:
         ----------------------------------
         If you intend to use the restart option (by passing a simulation number
         n>0 to create), the executable is called with
-        subprocess.run([executable, directory/hashid.json,
+        subprocess.run([interpreter, executable, directory/hashid.json,
         directory/hashid0xN.filetype, directory/hashid0x(N-1).filetype],...)
         that is it must take a third argument (the previous simulation)
         """
@@ -224,6 +268,11 @@ class Manager:
     def filetype(self) -> str:
         """File extension of the output files"""
         return self.__filetype
+    
+    @property
+    def interpreter(self) -> list[str]:
+        """The interpreter that runs the executable."""
+        return self.__interpreter
 
     @directory.setter
     def directory(self, directory: PathLike):
@@ -237,6 +286,17 @@ class Manager:
     @filetype.setter
     def filetype(self, filetype: str):
         self.__filetype = filetype
+
+    @interpreter.setter
+    def interpreter(self, interpreter: str | list[str] | None):
+        if interpreter is None or len(interpreter) == 0:
+            self.__interpreter = []
+        elif type(interpreter) == str:
+            self.__interpreter = interpreter.split()
+        elif type(interpreter) == list:
+            self.__interpreter = interpreter
+        else:
+            raise Exception("interpreter must be None, a string or a list of strings")
 
     def create(
         self,
@@ -315,24 +375,7 @@ class Manager:
                     json.dump(js, f, sort_keys=True, ensure_ascii=True, indent=4)
             # Run the code to create output file
             try:
-                # Check if the simulation is a restart
-                if n == 0:
-                    process = subprocess.run(
-                        [self.__executable, self.jsonfile(js), ncfile],
-                        check=True,
-                        capture_output=True,
-                    )
-                    if stdout == "display":
-                        print(process.stdout)
-                else:
-                    previous_ncfile = self.outfile(js, n - 1)
-                    process = subprocess.run(
-                        [self.__executable, self.jsonfile(js), ncfile, previous_ncfile],
-                        check=True,
-                        capture_output=True,
-                    )
-                    if stdout == "display":
-                        print(process.stdout)
+                self.__execute(js, ncfile, n, stdout)
             except subprocess.CalledProcessError as e:
                 # clean up entry and escalate exception
                 if os.path.isfile(ncfile):
@@ -345,6 +388,24 @@ class Manager:
                     raise e
 
             return ncfile
+
+    def __execute(self, js, ncfile, n=0, stdout="ignore"):
+        """Helper function to run the executable with the correct arguments
+
+        This is used in create to keep the code cleaner and reduce identation depth.
+        """
+        if self.__executable is None:
+            raise Exception("Executable not set! Set it with m.executable = '...'")
+
+        command = self.__interpreter + [self.__executable, self.jsonfile(js), ncfile]
+
+        # Check if the simulation is a restart
+        if n > 0:
+            previous_ncfile = self.outfile(js, n - 1)
+            command.append(previous_ncfile)
+        process = subprocess.run(command, check=True, capture_output=True)
+        if stdout == "display":
+            print(process.stdout)
 
     def recreate(
         self,

--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -29,8 +29,11 @@ class Repeater:
     """
 
     def __init__(
-        self, executable="./execute.sh", inputfile="temp.json", outputfile="temp.nc",
-        interpreter: str | list[str] | None = None
+        self,
+        executable="./execute.sh",
+        inputfile="temp.json",
+        outputfile="temp.nc",
+        interpreter: str | list[str] | None = None,
     ):
         """Set the executable and files to use in the run method"""
         self.executable = executable
@@ -110,7 +113,7 @@ class Repeater:
                     *self.__interpreter,
                     self.__executable,
                     self.__inputfile,
-                    self.__outputfile
+                    self.__outputfile,
                 ],
                 check=True,
                 capture_output=True,
@@ -403,11 +406,7 @@ class Manager:
         if self.__executable is None:
             raise Exception("Executable not set! Set it with m.executable = '...'")
 
-        command = [
-                    *self.__interpreter,
-                    self.__executable,
-                    self.jsonfile(js),
-                    ncfile]
+        command = [*self.__interpreter, self.__executable, self.jsonfile(js), ncfile]
 
         # Check if the simulation is a restart
         if n > 0:
@@ -676,37 +675,21 @@ class Manager:
             )
         if hashid in registry:
             if name != registry[hashid]:
-                raise Exception(
-                    "The name '"
-                    + name
-                    + "' cannot be used! The\
- input file is already known under the name '"
-                    + registry[hashid]
-                    + "'. Use\
- delete to clear the registry."
-                )
+                raise Exception("The name '" + name + "' cannot be used! The\
+ input file is already known under the name '" + registry[hashid] + "'. Use\
+ delete to clear the registry.")
         else:
             jsonfile = os.path.join(self.__directory, hashid + ".json")
             if os.path.isfile(jsonfile):
-                raise Exception(
-                    "The name '"
-                    + name
-                    + "' cannot be used! The\
- input file is already known under the name '"
-                    + jsonfile
-                    + "'. Use\
- delete to clear the registry."
-                )
+                raise Exception("The name '" + name + "' cannot be used! The\
+ input file is already known under the name '" + jsonfile + "'. Use\
+ delete to clear the registry.")
 
             registry[hashid] = name
         for key, value in registry.items():
             if (value == name) and key != hashid:
-                raise Exception(
-                    "The name '"
-                    + name
-                    + "' is already in use\
- for a different simulation. Choose a different name!"
-                )
+                raise Exception("The name '" + name + "' is already in use\
+ for a different simulation. Choose a different name!")
 
         self.set_registry(registry)
 

--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -30,7 +30,7 @@ class Repeater:
 
     def __init__(
         self, executable="./execute.sh", inputfile="temp.json", outputfile="temp.nc",
-        interpreter: str | list[str] = None
+        interpreter: str | list[str] | None = None
     ):
         """Set the executable and files to use in the run method"""
         self.executable = executable
@@ -38,9 +38,9 @@ class Repeater:
         self.outputfile = outputfile
         if interpreter is None or len(interpreter) == 0:
             self.interpreter = []
-        elif type(interpreter) == str:
+        elif type(interpreter) is str:
             self.interpreter = interpreter.split()
-        elif type(interpreter) == list:
+        elif type(interpreter) is list:
             self.interpreter = interpreter
         else:
             raise Exception("interpreter must be None, a string or a list of strings")
@@ -56,7 +56,7 @@ class Repeater:
     @property
     def outputfile(self):
         return self.__outputfile
-    
+
     @property
     def interpreter(self):
         return self.__interpreter
@@ -77,9 +77,9 @@ class Repeater:
     def interpreter(self, interpreter):
         if interpreter is None or len(interpreter) == 0:
             self.__interpreter = []
-        elif type(interpreter) == str:
+        elif type(interpreter) is str:
             self.__interpreter = interpreter.split()
-        elif type(interpreter) == list:
+        elif type(interpreter) is list:
             self.__interpreter = interpreter
         else:
             raise Exception("interpreter must be None, a string or a list of strings")
@@ -106,7 +106,12 @@ class Repeater:
             json.dump(js, f, sort_keys=True, ensure_ascii=True, indent=4)
         try:
             process = subprocess.run(
-                self.__interpreter + [self.__executable, self.__inputfile, self.__outputfile],
+                [
+                    *self.__interpreter,
+                    self.__executable,
+                    self.__inputfile,
+                    self.__outputfile
+                ],
                 check=True,
                 capture_output=True,
             )
@@ -204,33 +209,34 @@ class Manager:
             file extension of the output files
         executable:
             The executable that generates the data.
-            executable is called using subprocess.run([interpreter, executable, 
+            executable is called using subprocess.run([interpreter, executable,
             directory/hashid.json, directory/hashid.filetype],...) with
-            2 arguments - a json file as input (do not change the input else the file is not
-            recognized any more) and one output file (that executable needs to
+            2 arguments - a json file as input (do not change the input else the file
+            is not recognized any more) and one output file (that executable needs to
             generate) (if your code does not take json as input you can for example
             parse json in bash using jq)
         interpreter:
             (optional) If your executable is not directly runnable but needs to be
             called via an interpreter (e.g. python, julia, R, powershell, etc.) you can
-            specify the interpreter here as a whitespace separated string or list of strings.
-            For example if your executable is a python script you can set interpreter="python.exe"
-            and the code will be called as subprocess.run(["python.exe", executable, ...],...)
-            You can also include interpreter arguments here. For example to run in a specific 
-            conda environment, set interpreter=["conda", "run", "-n", "myenv"]
-            or interpreter="conda run -n myenv" and the code will be called as
-            subprocess.run(["conda", "run", "-n", "myenv", executable, ...],...)
+            specify the interpreter here as a whitespace separated string or list of
+            strings. For example if your executable is a python script you can set
+            interpreter="python.exe" and the code will be called as
+            subprocess.run(["python.exe", executable, ...],...)
+            You can also include interpreter arguments here. For example to run in
+            a specific conda environment, set interpreter=["conda", "run", "-n",
+            "myenv"] or interpreter="conda run -n myenv" and the code will be called
+            as subprocess.run(["conda", "run", "-n", "myenv", executable, ...],...)
         """
         self.directory = directory
         os.makedirs(self.__directory, exist_ok=True)
         self.filetype = filetype
         self.executable = executable
-                
+
         if interpreter is None or len(interpreter) == 0:
             self.interpreter = []
-        elif type(interpreter) == str:
+        elif type(interpreter) is str:
             self.interpreter = interpreter.split()
-        elif type(interpreter) == list:
+        elif type(interpreter) is list:
             self.interpreter = interpreter
         else:
             raise Exception("interpreter must be None, a string or a list of strings")
@@ -268,7 +274,7 @@ class Manager:
     def filetype(self) -> str:
         """File extension of the output files"""
         return self.__filetype
-    
+
     @property
     def interpreter(self) -> list[str]:
         """The interpreter that runs the executable."""
@@ -291,9 +297,9 @@ class Manager:
     def interpreter(self, interpreter: str | list[str] | None):
         if interpreter is None or len(interpreter) == 0:
             self.__interpreter = []
-        elif type(interpreter) == str:
+        elif type(interpreter) is str:
             self.__interpreter = interpreter.split()
-        elif type(interpreter) == list:
+        elif type(interpreter) is list:
             self.__interpreter = interpreter
         else:
             raise Exception("interpreter must be None, a string or a list of strings")
@@ -397,7 +403,11 @@ class Manager:
         if self.__executable is None:
             raise Exception("Executable not set! Set it with m.executable = '...'")
 
-        command = self.__interpreter + [self.__executable, self.jsonfile(js), ncfile]
+        command = [
+                    *self.__interpreter,
+                    self.__executable,
+                    self.jsonfile(js),
+                    ncfile]
 
         # Check if the simulation is a restart
         if n > 0:

--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -68,7 +68,9 @@ class Repeater:
     def outputfile(self, outputfile):
         self.__outputfile = outputfile
 
-    def run(self, js: JSONDict, error: str = "display", stdout: str = "ignore"):
+    def run(
+        self, js: JSONDict, error: str = "display", stdout: str = "ignore", **kwargs
+    ):
         """Write inputfile and then run a simulation
 
         Parameters
@@ -84,6 +86,8 @@ class Repeater:
         stdout:
             - "ignore" throw away std output
             - "display" print( process.stdout)
+        kwargs:
+            additional arguments passed to subprocess.run in the run method
 
         """
         with open(self.inputfile, "w") as f:
@@ -99,6 +103,7 @@ class Repeater:
                 command,
                 check=True,
                 capture_output=True,
+                **kwargs,
             )
 
             if stdout == "display":
@@ -271,6 +276,7 @@ class Manager:
         name: str = "",
         error: str = "raise",
         stdout: str = "ignore",
+        **kwargs,
     ) -> str:
         """Run a simulation if outfile does not exist yet
 
@@ -316,6 +322,8 @@ class Manager:
         stdout :
             - "ignore": throw away std output
             - "display": ``print( process.stdout)``
+        kwargs :
+            additional arguments passed to subprocess.run in the create method
 
         Return
         ------
@@ -341,7 +349,7 @@ class Manager:
                     json.dump(js, f, sort_keys=True, ensure_ascii=True, indent=4)
             # Run the code to create output file
             try:
-                self.__execute(js, ncfile, n, stdout)
+                self.__execute(js, ncfile, n, stdout, **kwargs)
             except subprocess.CalledProcessError as e:
                 # clean up entry and escalate exception
                 if os.path.isfile(ncfile):
@@ -355,7 +363,7 @@ class Manager:
 
             return ncfile
 
-    def __execute(self, js, ncfile, n=0, stdout="ignore"):
+    def __execute(self, js, ncfile, n=0, stdout="ignore", **kwargs):
         """Helper function to run the executable with the correct arguments
 
         This is used in create to keep the code cleaner and reduce identation depth.
@@ -373,7 +381,7 @@ class Manager:
         if n > 0:
             previous_ncfile = self.outfile(js, n - 1)
             command.append(previous_ncfile)
-        process = subprocess.run(command, check=True, capture_output=True)
+        process = subprocess.run(command, check=True, capture_output=True, **kwargs)
         if stdout == "display":
             print(process.stdout)
 

--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -30,23 +30,14 @@ class Repeater:
 
     def __init__(
         self,
-        executable="./execute.sh",
+        executable: str | list[str] = "./execute.sh",
         inputfile="temp.json",
         outputfile="temp.nc",
-        interpreter: str | list[str] | None = None,
     ):
         """Set the executable and files to use in the run method"""
-        self.executable = executable
         self.inputfile = inputfile
         self.outputfile = outputfile
-        if interpreter is None or len(interpreter) == 0:
-            self.interpreter = []
-        elif type(interpreter) is str:
-            self.interpreter = interpreter.split()
-        elif type(interpreter) is list:
-            self.interpreter = interpreter
-        else:
-            raise Exception("interpreter must be None, a string or a list of strings")
+        self.executable = executable
 
     @property
     def executable(self):
@@ -60,13 +51,16 @@ class Repeater:
     def outputfile(self):
         return self.__outputfile
 
-    @property
-    def interpreter(self):
-        return self.__interpreter
-
     @executable.setter
     def executable(self, executable):
-        self.__executable = executable
+        if executable is None or type(executable) not in [str, list]:
+            raise Exception("Executable must be given as a string or list of strings")
+        elif len(executable) == 0:
+            raise Exception("Executable cannot be empty string or list")
+        elif type(executable) is str:
+            self.__executable = [executable]
+        elif type(executable) is list:
+            self.__executable = executable
 
     @inputfile.setter
     def inputfile(self, inputfile):
@@ -75,17 +69,6 @@ class Repeater:
     @outputfile.setter
     def outputfile(self, outputfile):
         self.__outputfile = outputfile
-
-    @interpreter.setter
-    def interpreter(self, interpreter):
-        if interpreter is None or len(interpreter) == 0:
-            self.__interpreter = []
-        elif type(interpreter) is str:
-            self.__interpreter = interpreter.split()
-        elif type(interpreter) is list:
-            self.__interpreter = interpreter
-        else:
-            raise Exception("interpreter must be None, a string or a list of strings")
 
     def run(self, js: JSONDict, error: str = "display", stdout: str = "ignore"):
         """Write inputfile and then run a simulation
@@ -110,8 +93,7 @@ class Repeater:
         try:
             process = subprocess.run(
                 [
-                    *self.__interpreter,
-                    self.__executable,
+                    *self.__executable,
                     self.__inputfile,
                     self.__outputfile,
                 ],
@@ -178,8 +160,7 @@ class Manager:
         self,
         directory: PathLike = "./data",
         filetype: str = "nc",
-        executable: str = "./execute.sh",
-        interpreter: str | list[str] | None = None,
+        executable: str | list[str] = "./execute.sh",
     ):
         """Init the Manager class
 
@@ -192,8 +173,7 @@ class Manager:
 
             subprocess.run(
                 [
-                    interpreter,
-                    executable,
+                    *executable,
                     directory/hashid.json,
                     directory/hashid0xN.filetype,
                     directory/hashid0x(N-1).filetype,
@@ -211,38 +191,25 @@ class Manager:
         filetype:
             file extension of the output files
         executable:
-            The executable that generates the data.
-            executable is called using subprocess.run([interpreter, executable,
+            The executable that generates the data. Can be a string or list of strings.
+            Since executable is passed to subprocess.run, it can be a command with
+            arguments. If your code is an executable script or single command, this
+            can be passed just as a string (e.g. "./execute.sh" or "cp"). If your code
+            needs to be run with an interpreter or needs additional arguments (e.g.
+            "python script.py", "ls -l"), then you must pass the executable as a list
+            of strings (e.g. ["python", "script.py"], ["ls", "-l"]). Same as it would
+            be given to subprocess.run.
+            executable is called using subprocess.run(executable + [
             directory/hashid.json, directory/hashid.filetype],...) with
-            2 arguments - a json file as input (do not change the input else the file
+            a json file as input (do not change the input else the file
             is not recognized any more) and one output file (that executable needs to
             generate) (if your code does not take json as input you can for example
             parse json in bash using jq)
-        interpreter:
-            (optional) If your executable is not directly runnable but needs to be
-            called via an interpreter (e.g. python, julia, R, powershell, etc.) you can
-            specify the interpreter here as a whitespace separated string or list of
-            strings. For example if your executable is a python script you can set
-            interpreter="python.exe" and the code will be called as
-            subprocess.run(["python.exe", executable, ...],...)
-            You can also include interpreter arguments here. For example to run in
-            a specific conda environment, set interpreter=["conda", "run", "-n",
-            "myenv"] or interpreter="conda run -n myenv" and the code will be called
-            as subprocess.run(["conda", "run", "-n", "myenv", executable, ...],...)
         """
         self.directory = directory
         os.makedirs(self.__directory, exist_ok=True)
         self.filetype = filetype
         self.executable = executable
-
-        if interpreter is None or len(interpreter) == 0:
-            self.interpreter = []
-        elif type(interpreter) is str:
-            self.interpreter = interpreter.split()
-        elif type(interpreter) is list:
-            self.interpreter = interpreter
-        else:
-            raise Exception("interpreter must be None, a string or a list of strings")
 
     @property
     def directory(self) -> PathLike:
@@ -253,10 +220,10 @@ class Manager:
         return self.__directory
 
     @property
-    def executable(self) -> str:
+    def executable(self) -> list[str]:
         """The executable that generates the data.
 
-        The create method calls subprocess.run([interpreter, executable,
+        The create method calls subprocess.run([*executable,
         directory/hashid.json, directory/hashid.filetype],...) that is it must
         take 2 arguments - a json file as input (do not change the input else
         the file is not recognized any more) and one output file (that
@@ -267,7 +234,7 @@ class Manager:
         ----------------------------------
         If you intend to use the restart option (by passing a simulation number
         n>0 to create), the executable is called with
-        subprocess.run([interpreter, executable, directory/hashid.json,
+        subprocess.run([*executable, directory/hashid.json,
         directory/hashid0xN.filetype, directory/hashid0x(N-1).filetype],...)
         that is it must take a third argument (the previous simulation)
         """
@@ -278,34 +245,25 @@ class Manager:
         """File extension of the output files"""
         return self.__filetype
 
-    @property
-    def interpreter(self) -> list[str]:
-        """The interpreter that runs the executable."""
-        return self.__interpreter
-
     @directory.setter
     def directory(self, directory: PathLike):
         self.__directory = directory
         os.makedirs(self.__directory, exist_ok=True)
 
     @executable.setter
-    def executable(self, executable: str):
-        self.__executable = executable
+    def executable(self, executable: str | list[str]):
+        if executable is None or type(executable) not in [str, list]:
+            raise Exception("Executable must be given as a string or list of strings")
+        if len(executable) == 0:
+            raise Exception("Executable cannot be empty string or list")
+        elif type(executable) is str:
+            self.__executable = [executable]
+        elif type(executable) is list:
+            self.__executable = executable
 
     @filetype.setter
     def filetype(self, filetype: str):
         self.__filetype = filetype
-
-    @interpreter.setter
-    def interpreter(self, interpreter: str | list[str] | None):
-        if interpreter is None or len(interpreter) == 0:
-            self.__interpreter = []
-        elif type(interpreter) is str:
-            self.__interpreter = interpreter.split()
-        elif type(interpreter) is list:
-            self.__interpreter = interpreter
-        else:
-            raise Exception("interpreter must be None, a string or a list of strings")
 
     def create(
         self,
@@ -406,7 +364,7 @@ class Manager:
         if self.__executable is None:
             raise Exception("Executable not set! Set it with m.executable = '...'")
 
-        command = [*self.__interpreter, self.__executable, self.jsonfile(js), ncfile]
+        command = [*self.__executable, self.jsonfile(js), ncfile]
 
         # Check if the simulation is a restart
         if n > 0:

--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -35,9 +35,9 @@ class Repeater:
         outputfile="temp.nc",
     ):
         """Set the executable and files to use in the run method"""
+        self.executable = executable
         self.inputfile = inputfile
         self.outputfile = outputfile
-        self.executable = executable
 
     @property
     def executable(self):
@@ -57,9 +57,7 @@ class Repeater:
             raise Exception("Executable must be given as a string or list of strings")
         elif len(executable) == 0:
             raise Exception("Executable cannot be empty string or list")
-        elif type(executable) is str:
-            self.__executable = [executable]
-        elif type(executable) is list:
+        elif type(executable) is str or type(executable) is list:
             self.__executable = executable
 
     @inputfile.setter
@@ -91,15 +89,18 @@ class Repeater:
         with open(self.inputfile, "w") as f:
             json.dump(js, f, sort_keys=True, ensure_ascii=True, indent=4)
         try:
+            command = []
+            if type(self.__executable) is str:
+                command = [self.__executable, self.inputfile, self.outputfile]
+            elif type(self.__executable) is list:
+                command = [*self.__executable, self.inputfile, self.outputfile]
+
             process = subprocess.run(
-                [
-                    *self.__executable,
-                    self.__inputfile,
-                    self.__outputfile,
-                ],
+                command,
                 check=True,
                 capture_output=True,
             )
+
             if stdout == "display":
                 print(process.stdout)
         except subprocess.CalledProcessError as e:
@@ -173,7 +174,7 @@ class Manager:
 
             subprocess.run(
                 [
-                    *executable,
+                    executable,
                     directory/hashid.json,
                     directory/hashid0xN.filetype,
                     directory/hashid0x(N-1).filetype,
@@ -199,7 +200,7 @@ class Manager:
             "python script.py", "ls -l"), then you must pass the executable as a list
             of strings (e.g. ["python", "script.py"], ["ls", "-l"]). Same as it would
             be given to subprocess.run.
-            executable is called using subprocess.run(executable + [
+            executable is called using subprocess.run([executable,
             directory/hashid.json, directory/hashid.filetype],...) with
             a json file as input (do not change the input else the file
             is not recognized any more) and one output file (that executable needs to
@@ -223,7 +224,7 @@ class Manager:
     def executable(self) -> list[str]:
         """The executable that generates the data.
 
-        The create method calls subprocess.run([*executable,
+        The create method calls subprocess.run([executable,
         directory/hashid.json, directory/hashid.filetype],...) that is it must
         take 2 arguments - a json file as input (do not change the input else
         the file is not recognized any more) and one output file (that
@@ -256,9 +257,7 @@ class Manager:
             raise Exception("Executable must be given as a string or list of strings")
         if len(executable) == 0:
             raise Exception("Executable cannot be empty string or list")
-        elif type(executable) is str:
-            self.__executable = [executable]
-        elif type(executable) is list:
+        elif type(executable) is str or type(executable) is list:
             self.__executable = executable
 
     @filetype.setter
@@ -364,7 +363,11 @@ class Manager:
         if self.__executable is None:
             raise Exception("Executable not set! Set it with m.executable = '...'")
 
-        command = [*self.__executable, self.jsonfile(js), ncfile]
+        command = []
+        if type(self.__executable) is str:
+            command = [self.__executable, self.jsonfile(js), ncfile]
+        elif type(self.__executable) is list:
+            command = [*self.__executable, self.jsonfile(js), ncfile]
 
         # Check if the simulation is a restart
         if n > 0:

--- a/simplesimdb.py
+++ b/simplesimdb.py
@@ -69,7 +69,14 @@ class Repeater:
         self.__outputfile = outputfile
 
     def run(
-        self, js: JSONDict, error: str = "display", stdout: str = "ignore", **kwargs
+        self,
+        js: JSONDict,
+        error: str = "display",
+        stdout: str = "ignore",
+        *,
+        check: bool = True,
+        capture_output: bool = True,
+        **kwargs,
     ):
         """Write inputfile and then run a simulation
 
@@ -86,6 +93,13 @@ class Repeater:
         stdout:
             - "ignore" throw away std output
             - "display" print( process.stdout)
+        check:
+            passed to subprocess.run, if True a non-zero exit code raises a
+            subprocess.CalledProcessError, if False, no exception is raised
+            and you can check the return code with process.returncode
+        capture_output:
+            passed to subprocess.run, if True, stdout and stderr are captured
+            and can be accessed with process.stdout and process.stderr.
         kwargs:
             additional arguments passed to subprocess.run in the run method
 
@@ -101,8 +115,8 @@ class Repeater:
 
             process = subprocess.run(
                 command,
-                check=True,
-                capture_output=True,
+                check=check,
+                capture_output=capture_output,
                 **kwargs,
             )
 
@@ -276,6 +290,9 @@ class Manager:
         name: str = "",
         error: str = "raise",
         stdout: str = "ignore",
+        *,
+        check: bool = True,
+        capture_output: bool = True,
         **kwargs,
     ) -> str:
         """Run a simulation if outfile does not exist yet
@@ -322,6 +339,13 @@ class Manager:
         stdout :
             - "ignore": throw away std output
             - "display": ``print( process.stdout)``
+        check :
+            passed to subprocess.run, if True a non-zero exit code raises a
+            subprocess.CalledProcessError, if False, no exception is raised
+            and you can check the return code with process.returncode
+        capture_output :
+            passed to subprocess.run, if True, stdout and stderr are captured
+            and can be accessed with process.stdout and process.stderr,
         kwargs :
             additional arguments passed to subprocess.run in the create method
 
@@ -349,7 +373,15 @@ class Manager:
                     json.dump(js, f, sort_keys=True, ensure_ascii=True, indent=4)
             # Run the code to create output file
             try:
-                self.__execute(js, ncfile, n, stdout, **kwargs)
+                self.__execute(
+                    js,
+                    ncfile,
+                    n,
+                    stdout,
+                    check=check,
+                    capture_output=capture_output,
+                    **kwargs,
+                )
             except subprocess.CalledProcessError as e:
                 # clean up entry and escalate exception
                 if os.path.isfile(ncfile):
@@ -363,7 +395,17 @@ class Manager:
 
             return ncfile
 
-    def __execute(self, js, ncfile, n=0, stdout="ignore", **kwargs):
+    def __execute(
+        self,
+        js,
+        ncfile,
+        n=0,
+        stdout="ignore",
+        *,
+        check=True,
+        capture_output=True,
+        **kwargs,
+    ):
         """Helper function to run the executable with the correct arguments
 
         This is used in create to keep the code cleaner and reduce identation depth.
@@ -381,7 +423,9 @@ class Manager:
         if n > 0:
             previous_ncfile = self.outfile(js, n - 1)
             command.append(previous_ncfile)
-        process = subprocess.run(command, check=True, capture_output=True, **kwargs)
+        process = subprocess.run(
+            command, check=check, capture_output=capture_output, **kwargs
+        )
         if stdout == "display":
             print(process.stdout)
 

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -1,10 +1,12 @@
-import os.path
+import os
 
 import pytest
 
 import simplesimdb as sim
 
 # Run with pytest -s . to see stdout output
+
+is_windows = os.name == "nt"
 
 
 def test_construction_and_destruction():
@@ -17,12 +19,13 @@ def test_construction_and_destruction():
 
 def test_creation():
     print("TEST CREATION")
-    m = sim.Manager(directory="creation_test", executable="cp", filetype="json")
+    executable = "cp" if not is_windows else "copy"
+    m = sim.Manager(directory="creation_test", executable=executable, filetype="json")
     assert m.directory == "creation_test"
-    assert m.executable == "cp"
+    assert m.executable == executable
     assert m.filetype == "json"
     inputdata = {"Hello": "World"}
-    m.create(inputdata)
+    m.create(inputdata, shell=is_windows)
     content = m.table()
     assert content == [inputdata]
     m.delete_all()
@@ -31,9 +34,10 @@ def test_creation():
 
 def test_creation_with_interpreter():
     print("TEST CREATION WITH INTERPRETER")
+    command = "cp" if not is_windows else "copy"
     script = (
         "import sys; import subprocess; "
-        "subprocess.run(['cp', sys.argv[1], sys.argv[2]])"
+        f"subprocess.run(['{command}', sys.argv[1], sys.argv[2]], shell=True)"
     )
     m = sim.Manager(
         directory="creation_interpreter_test",
@@ -44,7 +48,7 @@ def test_creation_with_interpreter():
     assert m.executable == ["python", "-c", script]
     assert m.filetype == "json"
     inputdata = {"Hello": "World"}
-    m.create(inputdata, 0)
+    m.create(inputdata, 0, shell=is_windows)
     content = m.table()
     assert content == [inputdata]
     m.delete_all()
@@ -53,11 +57,12 @@ def test_creation_with_interpreter():
 
 def test_selection():
     print("TEST SELECTION")
-    m = sim.Manager(directory="selection_test", executable="cp", filetype="json")
+    executable = "cp" if not is_windows else "copy"
+    m = sim.Manager(directory="selection_test", executable=executable, filetype="json")
     inputdata = {"Hello": "World"}
     inputdata2 = {"Hello": "World!"}
-    m.create(inputdata)
-    m.create(inputdata2)
+    m.create(inputdata, shell=is_windows)
+    m.create(inputdata2, shell=is_windows)
     data = m.select(inputdata)
     assert os.path.isfile(data)
     assert data == m.outfile(inputdata)
@@ -67,7 +72,16 @@ def test_selection():
 
 def test_restart():
     print("TEST RESTART")
-    m = sim.Manager(directory="restart_test", executable="touch", filetype="th")
+    executable = (
+        "touch"
+        if not is_windows
+        else [
+            "python",
+            "-c",
+            "import sys; open(sys.argv[2], 'a').close()",
+        ]
+    )
+    m = sim.Manager(directory="restart_test", executable=executable, filetype="th")
     inputdata = {"Hello": "World"}
     for i in range(0, 17):
         m.create(inputdata, i)
@@ -89,8 +103,17 @@ def test_restart():
 
 def test_named_creation():
     print("TEST NAMED CREATION")
+    executable = (
+        "touch"
+        if not is_windows
+        else [
+            "python",
+            "-c",
+            "import sys; open(sys.argv[2], 'a').close()",
+        ]
+    )
     m = sim.Manager(
-        directory="creation_named_test", executable="touch", filetype="json"
+        directory="creation_named_test", executable=executable, filetype="json"
     )
     inputdata = {"Hello": "World"}
     m.create(inputdata, 0)
@@ -107,13 +130,26 @@ def test_named_creation():
 def test_repeater():
     print("TEST REPEATER")
     os.makedirs("temp_repeater", exist_ok=True)
-    m = sim.Repeater("touch", "temp_repeater/temp.json", "temp_repeater/temp.nc")
+    executable = (
+        "touch"
+        if not is_windows
+        else [
+            "python",
+            "-c",
+            (
+                "import sys;"
+                "open(sys.argv[1], 'a').close();"
+                "open(sys.argv[2], 'a').close()"
+            ),
+        ]
+    )
+    m = sim.Repeater(executable, "temp_repeater/temp.json", "temp_repeater/temp.nc")
     inputdata = {"Hello": "World"}
     m.run(inputdata, error="display", stdout="display")
     assert os.path.isfile("temp_repeater/temp.json")
     assert os.path.isfile("temp_repeater/temp.nc")
     m.executable = "echo"
-    m.run(inputdata, error="display", stdout="display")
+    m.run(inputdata, error="display", stdout="display", shell=is_windows)
     m.clean()
     assert not os.path.isfile("temp_repeater/temp.json")
     assert not os.path.isfile("temp_repeater/temp.nc")
@@ -126,9 +162,19 @@ def test_repeater():
 def test_repeater_with_interpreter():
     print("TEST REPEATER WITH INTERPRETER")
     os.makedirs("temp_repeater_interpreter", exist_ok=True)
+    command = (
+        "'touch'"
+        if not is_windows
+        else (
+            "'python', '-c',"
+            "'import sys;"
+            'open(sys.argv[1], "a").close();'
+            'open(sys.argv[2], "a").close()\''
+        )
+    )
     script = (
         "import sys; import subprocess; "
-        "subprocess.run(['touch', sys.argv[1], sys.argv[2]])"
+        f"subprocess.run([{command}, sys.argv[1], sys.argv[2]])"
     )
     m = sim.Repeater(
         ["python", "-c", script],

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -30,9 +30,9 @@ def test_creation():
 def test_creation_with_interpreter():
     print("TEST CREATION WITH INTERPRETER")
     executable = (
-        'import sys; import subprocess; '
-        'subprocess.run(["cp", sys.argv[1], sys.argv[2]])'
-        )
+        "import sys; import subprocess; "
+        "subprocess.run(['cp', sys.argv[1], sys.argv[2]])"
+    )
     m = sim.Manager(
         directory="creation_interpreter_test",
         executable=executable,
@@ -127,9 +127,9 @@ def test_repeater_with_interpreter():
     print("TEST REPEATER WITH INTERPRETER")
     os.makedirs("temp_repeater_interpreter", exist_ok=True)
     executable = (
-            'import sys; import subprocess; '
-            'subprocess.run(["touch", sys.argv[1], sys.argv[2]])'
-            )
+        "import sys; import subprocess; "
+        "subprocess.run(['touch', sys.argv[1], sys.argv[2]])"
+    )
     m = sim.Repeater(
         executable,
         "temp_repeater_interpreter/temp.json",
@@ -141,9 +141,9 @@ def test_repeater_with_interpreter():
     assert os.path.isfile("temp_repeater_interpreter/temp.json")
     assert os.path.isfile("temp_repeater_interpreter/temp.nc")
     m.executable = (
-            'import sys; import subprocess; '
-            'subprocess.run(["echo", sys.argv[1], sys.argv[2]])'
-            )
+        "import sys; import subprocess; "
+        "subprocess.run(['echo', sys.argv[1], sys.argv[2]])"
+    )
     m.run(inputdata, error="display", stdout="display")
     m.clean()
     assert not os.path.isfile("temp_repeater_interpreter/temp.json")

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -37,7 +37,8 @@ def test_creation_with_interpreter():
     command = "cp" if not is_windows else "copy"
     script = (
         "import sys; import subprocess; "
-        f"subprocess.run(['{command}', sys.argv[1], sys.argv[2]], shell=True)"
+        f"subprocess.run(['{command}', sys.argv[1], sys.argv[2]], "
+        f"shell={is_windows})"
     )
     m = sim.Manager(
         directory="creation_interpreter_test",

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -1,5 +1,7 @@
 import os.path
 
+import pytest
+
 import simplesimdb as sim
 
 # Run with pytest -s . to see stdout output
@@ -17,7 +19,7 @@ def test_creation():
     print("TEST CREATION")
     m = sim.Manager(directory="creation_test", executable="cp", filetype="json")
     assert m.directory == "creation_test"
-    assert m.executable == ["cp"]
+    assert m.executable == "cp"
     assert m.filetype == "json"
     inputdata = {"Hello": "World"}
     m.create(inputdata)
@@ -150,3 +152,35 @@ def test_repeater_with_interpreter():
     temp_folder_empty = not os.listdir("temp_repeater_interpreter")
     if temp_folder_exists and temp_folder_empty:
         os.rmdir("temp_repeater_interpreter")
+
+
+def test_executable_validation():
+    print("TEST EXECUTABLE VALIDATION")
+    match = "Executable must be given as a string or list of strings"
+    with pytest.raises(Exception, match=match):
+        sim.Manager(
+            directory="executable_validation_test", executable=123, filetype="json"
+        )
+
+    match = "Executable cannot be empty string or list"
+    with pytest.raises(Exception, match=match):
+        sim.Manager(
+            directory="executable_validation_test", executable="", filetype="json"
+        )
+
+    with pytest.raises(Exception, match=match):
+        sim.Manager(
+            directory="executable_validation_test", executable=[], filetype="json"
+        )
+
+    m = sim.Manager(
+        directory="executable_validation_test", executable="echo", filetype="json"
+    )
+
+    assert m.executable == "echo"
+    m.executable = "ls -l"
+    assert m.executable == "ls -l"
+    m.executable = ["ls", "-l"]
+    assert m.executable == ["ls", "-l"]
+    m.delete_all()
+    assert not os.path.isdir(m.directory)

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -26,6 +26,26 @@ def test_creation():
     m.delete_all()
     assert not os.path.isdir(m.directory)
 
+def test_creation_with_interpreter():
+    print("TEST CREATION WITH INTERPRETER")
+    executable = 'import sys; import os; os.system("cp " + sys.argv[1] + " " + sys.argv[2])'
+    m = sim.Manager(
+        directory="creation_interpreter_test",
+        executable=executable,
+        filetype="json",
+        interpreter="python -c",
+    )
+    assert m.directory == "creation_interpreter_test"
+    assert m.executable == executable
+    assert m.filetype == "json"
+    assert m.interpreter == ["python", "-c"]
+    inputdata = {"Hello": "World"}
+    m.create(inputdata, 0)
+    content = m.table()
+    assert content == [inputdata]
+    m.delete_all()
+    assert not os.path.isdir(m.directory)
+
 
 def test_selection():
     print("TEST SELECTION")
@@ -82,13 +102,38 @@ def test_named_creation():
 
 def test_repeater():
     print("TEST REPEATER")
-    m = sim.Repeater("touch", "temp.json", "temp.nc")
+    os.makedirs("temp_repeater", exist_ok=True)
+    m = sim.Repeater("touch", "temp_repeater/temp.json", "temp_repeater/temp.nc")
     inputdata = {"Hello": "World"}
     m.run(inputdata, error="display", stdout="display")
-    assert os.path.isfile("temp.json")
-    assert os.path.isfile("temp.nc")
+    assert os.path.isfile("temp_repeater/temp.json")
+    assert os.path.isfile("temp_repeater/temp.nc")
     m.executable = "echo"
     m.run(inputdata, error="display", stdout="display")
     m.clean()
-    assert not os.path.isfile("temp.json")
-    assert not os.path.isfile("temp.nc")
+    assert not os.path.isfile("temp_repeater/temp.json")
+    assert not os.path.isfile("temp_repeater/temp.nc")
+    if os.path.isdir("temp_repeater") and not os.listdir("temp_repeater"):
+        os.rmdir("temp_repeater")
+
+def test_repeater_with_interpreter():
+    print("TEST REPEATER WITH INTERPRETER")
+    os.makedirs("temp_repeater_interpreter", exist_ok=True)
+    executable = 'import sys; import os; os.system("touch " + sys.argv[1] + " " + sys.argv[2])'
+    m = sim.Repeater(
+        executable,
+        "temp_repeater_interpreter/temp.json",
+        "temp_repeater_interpreter/temp.nc",
+        interpreter="python -c",
+    )
+    inputdata = {"Hello": "World"}
+    m.run(inputdata, error="display", stdout="display")
+    assert os.path.isfile("temp_repeater_interpreter/temp.json")
+    assert os.path.isfile("temp_repeater_interpreter/temp.nc")
+    m.executable = 'import sys; import os; os.system("echo " + sys.argv[1] + " " + sys.argv[2])'
+    m.run(inputdata, error="display", stdout="display")
+    m.clean()
+    assert not os.path.isfile("temp_repeater_interpreter/temp.json")
+    assert not os.path.isfile("temp_repeater_interpreter/temp.nc")
+    if os.path.isdir("temp_repeater_interpreter") and not os.listdir("temp_repeater_interpreter"):
+        os.rmdir("temp_repeater_interpreter")

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -8,6 +8,8 @@ import simplesimdb as sim
 
 is_windows = os.name == "nt"
 
+py_touch = "import sys; [open(arg, 'a').close() for arg in sys.argv[1:]]"
+
 
 def test_construction_and_destruction():
     print("TEST")
@@ -34,12 +36,7 @@ def test_creation():
 
 def test_creation_with_interpreter():
     print("TEST CREATION WITH INTERPRETER")
-    command = "cp" if not is_windows else "copy"
-    script = (
-        "import sys; import subprocess; "
-        f"subprocess.run(['{command}', sys.argv[1], sys.argv[2]], "
-        f"shell={is_windows})"
-    )
+    script = "import sys; import shutil; shutil.copy(sys.argv[1], sys.argv[2])"
     m = sim.Manager(
         directory="creation_interpreter_test",
         executable=["python", "-c", script],
@@ -73,15 +70,7 @@ def test_selection():
 
 def test_restart():
     print("TEST RESTART")
-    executable = (
-        "touch"
-        if not is_windows
-        else [
-            "python",
-            "-c",
-            "import sys; open(sys.argv[2], 'a').close()",
-        ]
-    )
+    executable = ["python", "-c", py_touch]
     m = sim.Manager(directory="restart_test", executable=executable, filetype="th")
     inputdata = {"Hello": "World"}
     for i in range(0, 17):
@@ -104,15 +93,7 @@ def test_restart():
 
 def test_named_creation():
     print("TEST NAMED CREATION")
-    executable = (
-        "touch"
-        if not is_windows
-        else [
-            "python",
-            "-c",
-            "import sys; open(sys.argv[2], 'a').close()",
-        ]
-    )
+    executable = ["python", "-c", py_touch]
     m = sim.Manager(
         directory="creation_named_test", executable=executable, filetype="json"
     )
@@ -131,19 +112,7 @@ def test_named_creation():
 def test_repeater():
     print("TEST REPEATER")
     os.makedirs("temp_repeater", exist_ok=True)
-    executable = (
-        "touch"
-        if not is_windows
-        else [
-            "python",
-            "-c",
-            (
-                "import sys;"
-                "open(sys.argv[1], 'a').close();"
-                "open(sys.argv[2], 'a').close()"
-            ),
-        ]
-    )
+    executable = ["python", "-c", py_touch]
     m = sim.Repeater(executable, "temp_repeater/temp.json", "temp_repeater/temp.nc")
     inputdata = {"Hello": "World"}
     m.run(inputdata, error="display", stdout="display")
@@ -158,47 +127,6 @@ def test_repeater():
     temp_folder_empty = not os.listdir("temp_repeater")
     if temp_folder_exists and temp_folder_empty:
         os.rmdir("temp_repeater")
-
-
-def test_repeater_with_interpreter():
-    print("TEST REPEATER WITH INTERPRETER")
-    os.makedirs("temp_repeater_interpreter", exist_ok=True)
-    command = (
-        "'touch'"
-        if not is_windows
-        else (
-            "'python', '-c',"
-            "'import sys;"
-            'open(sys.argv[1], "a").close();'
-            'open(sys.argv[2], "a").close()\''
-        )
-    )
-    script = (
-        "import sys; import subprocess; "
-        f"subprocess.run([{command}, sys.argv[1], sys.argv[2]])"
-    )
-    m = sim.Repeater(
-        ["python", "-c", script],
-        "temp_repeater_interpreter/temp.json",
-        "temp_repeater_interpreter/temp.nc",
-    )
-    inputdata = {"Hello": "World"}
-    m.run(inputdata, error="display", stdout="display")
-    assert os.path.isfile("temp_repeater_interpreter/temp.json")
-    assert os.path.isfile("temp_repeater_interpreter/temp.nc")
-    script = (
-        "import sys; import subprocess; "
-        "subprocess.run(['echo', sys.argv[1], sys.argv[2]])"
-    )
-    m.executable = ["python", "-c", script]
-    m.run(inputdata, error="display", stdout="display")
-    m.clean()
-    assert not os.path.isfile("temp_repeater_interpreter/temp.json")
-    assert not os.path.isfile("temp_repeater_interpreter/temp.nc")
-    temp_folder_exists = os.path.isdir("temp_repeater_interpreter")
-    temp_folder_empty = not os.listdir("temp_repeater_interpreter")
-    if temp_folder_exists and temp_folder_empty:
-        os.rmdir("temp_repeater_interpreter")
 
 
 def test_executable_validation():

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -26,9 +26,13 @@ def test_creation():
     m.delete_all()
     assert not os.path.isdir(m.directory)
 
+
 def test_creation_with_interpreter():
     print("TEST CREATION WITH INTERPRETER")
-    executable = 'import sys; import os; os.system("cp " + sys.argv[1] + " " + sys.argv[2])'
+    executable = (
+        'import sys; import subprocess; '
+        'subprocess.run(["cp", sys.argv[1], sys.argv[2]])'
+        )
     m = sim.Manager(
         directory="creation_interpreter_test",
         executable=executable,
@@ -113,13 +117,19 @@ def test_repeater():
     m.clean()
     assert not os.path.isfile("temp_repeater/temp.json")
     assert not os.path.isfile("temp_repeater/temp.nc")
-    if os.path.isdir("temp_repeater") and not os.listdir("temp_repeater"):
+    temp_folder_exists = os.path.isdir("temp_repeater")
+    temp_folder_empty = not os.listdir("temp_repeater")
+    if temp_folder_exists and temp_folder_empty:
         os.rmdir("temp_repeater")
+
 
 def test_repeater_with_interpreter():
     print("TEST REPEATER WITH INTERPRETER")
     os.makedirs("temp_repeater_interpreter", exist_ok=True)
-    executable = 'import sys; import os; os.system("touch " + sys.argv[1] + " " + sys.argv[2])'
+    executable = (
+            'import sys; import subprocess; '
+            'subprocess.run(["touch", sys.argv[1], sys.argv[2]])'
+            )
     m = sim.Repeater(
         executable,
         "temp_repeater_interpreter/temp.json",
@@ -130,10 +140,15 @@ def test_repeater_with_interpreter():
     m.run(inputdata, error="display", stdout="display")
     assert os.path.isfile("temp_repeater_interpreter/temp.json")
     assert os.path.isfile("temp_repeater_interpreter/temp.nc")
-    m.executable = 'import sys; import os; os.system("echo " + sys.argv[1] + " " + sys.argv[2])'
+    m.executable = (
+            'import sys; import subprocess; '
+            'subprocess.run(["echo", sys.argv[1], sys.argv[2]])'
+            )
     m.run(inputdata, error="display", stdout="display")
     m.clean()
     assert not os.path.isfile("temp_repeater_interpreter/temp.json")
     assert not os.path.isfile("temp_repeater_interpreter/temp.nc")
-    if os.path.isdir("temp_repeater_interpreter") and not os.listdir("temp_repeater_interpreter"):
+    temp_folder_exists = os.path.isdir("temp_repeater_interpreter")
+    temp_folder_empty = not os.listdir("temp_repeater_interpreter")
+    if temp_folder_exists and temp_folder_empty:
         os.rmdir("temp_repeater_interpreter")

--- a/test_simplesimdb.py
+++ b/test_simplesimdb.py
@@ -17,7 +17,7 @@ def test_creation():
     print("TEST CREATION")
     m = sim.Manager(directory="creation_test", executable="cp", filetype="json")
     assert m.directory == "creation_test"
-    assert m.executable == "cp"
+    assert m.executable == ["cp"]
     assert m.filetype == "json"
     inputdata = {"Hello": "World"}
     m.create(inputdata)
@@ -29,20 +29,18 @@ def test_creation():
 
 def test_creation_with_interpreter():
     print("TEST CREATION WITH INTERPRETER")
-    executable = (
+    script = (
         "import sys; import subprocess; "
         "subprocess.run(['cp', sys.argv[1], sys.argv[2]])"
     )
     m = sim.Manager(
         directory="creation_interpreter_test",
-        executable=executable,
+        executable=["python", "-c", script],
         filetype="json",
-        interpreter="python -c",
     )
     assert m.directory == "creation_interpreter_test"
-    assert m.executable == executable
+    assert m.executable == ["python", "-c", script]
     assert m.filetype == "json"
-    assert m.interpreter == ["python", "-c"]
     inputdata = {"Hello": "World"}
     m.create(inputdata, 0)
     content = m.table()
@@ -126,24 +124,24 @@ def test_repeater():
 def test_repeater_with_interpreter():
     print("TEST REPEATER WITH INTERPRETER")
     os.makedirs("temp_repeater_interpreter", exist_ok=True)
-    executable = (
+    script = (
         "import sys; import subprocess; "
         "subprocess.run(['touch', sys.argv[1], sys.argv[2]])"
     )
     m = sim.Repeater(
-        executable,
+        ["python", "-c", script],
         "temp_repeater_interpreter/temp.json",
         "temp_repeater_interpreter/temp.nc",
-        interpreter="python -c",
     )
     inputdata = {"Hello": "World"}
     m.run(inputdata, error="display", stdout="display")
     assert os.path.isfile("temp_repeater_interpreter/temp.json")
     assert os.path.isfile("temp_repeater_interpreter/temp.nc")
-    m.executable = (
+    script = (
         "import sys; import subprocess; "
         "subprocess.run(['echo', sys.argv[1], sys.argv[2]])"
     )
+    m.executable = ["python", "-c", script]
     m.run(inputdata, error="display", stdout="display")
     m.clean()
     assert not os.path.isfile("temp_repeater_interpreter/temp.json")


### PR DESCRIPTION
Based on PR #8, fix test for windows machines. For this, 2 changes have been implemented:

- Check the OS of the device to decide to use `bash` or `cmd` commands during tests.
- Allow passing kwargs to `subprocess.run` from `Manager.create` and `Repteater.run`,. this allows adding `shell=True` to run shell commands in windows without having to add interpreter. This also improves flexibility for the user.